### PR TITLE
Add simple login demo

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,20 @@ const PORT = process.env.PORT || 3000;
 
 app.use(express.static(path.join(__dirname, 'public')));
 app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
 app.use('/api/shopify', shopifyRoutes);
+
+app.get('/login', (req, res) => {
+  res.sendFile(path.join(__dirname, 'views', 'login.html'));
+});
+
+app.post('/login', (req, res) => {
+  const { email, password } = req.body;
+  if (email === 'trial@neurolynx.ai' && password === 'test123') {
+    return res.redirect('/');
+  }
+  res.redirect('/login?error=1');
+});
 
 app.get('/', (req, res) => {
   res.sendFile(path.join(__dirname, 'views', 'dashboard.html'));

--- a/public/style.css
+++ b/public/style.css
@@ -150,3 +150,23 @@ footer {
   color: #aaa;
   margin-top: 50px;
 }
+
+/* Login Form */
+.login-form {
+  max-width: 300px;
+  margin: 40px auto;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.login-form input {
+  padding: 10px;
+  border: 1px solid #e5e7eb;
+  border-radius: 6px;
+}
+
+.error {
+  color: #dc2626;
+  text-align: center;
+}

--- a/views/login.html
+++ b/views/login.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Login - Neurolynx AI Assistant</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  </head>
+  <body>
+    <div class="container">
+      <header>
+        <img src="/logo.png" alt="Logo" class="logo" />
+        <h1>Neurolynx AI Automation Assistant</h1>
+        <p class="tagline">Smarter selling for e-commerce brands</p>
+      </header>
+
+      <form action="/login" method="post" class="login-form">
+        <input type="email" name="email" placeholder="Email" required />
+        <input type="password" name="password" placeholder="Password" required />
+        <button type="submit">Login</button>
+      </form>
+      <p id="error" class="error" style="display: none">Login failed</p>
+    </div>
+    <script>
+      const params = new URLSearchParams(window.location.search);
+      if (params.get("error")) {
+        document.getElementById("error").style.display = "block";
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- serve `login.html` on `/login`
- handle login POST and redirect to dashboard
- show error message when login fails
- support `express.urlencoded` body parsing
- style the login form

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_684d346e189c8330b8563ebea7a509b6