### PR TITLE
Implement login protection and logout feature

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,24 @@ const path = require('path');
 const dotenv = require('dotenv');
 const shopifyRoutes = require('./routes/shopify');
 
+// Simple helper to parse cookies from request headers
+function parseCookies(cookieHeader = '') {
+  return cookieHeader.split(';').reduce((acc, pair) => {
+    const [key, ...v] = pair.trim().split('=');
+    if (!key) return acc;
+    acc[key] = decodeURIComponent(v.join('='));
+    return acc;
+  }, {});
+}
+
+function checkAuth(req, res, next) {
+  const cookies = parseCookies(req.headers.cookie);
+  if (cookies.loggedIn === 'true') {
+    return next();
+  }
+  res.redirect('/login');
+}
+
 dotenv.config();
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -19,12 +37,18 @@ app.get('/login', (req, res) => {
 app.post('/login', (req, res) => {
   const { email, password } = req.body;
   if (email === 'trial@neurolynx.ai' && password === 'test123') {
+    res.cookie('loggedIn', 'true', { httpOnly: true });
     return res.redirect('/');
   }
   res.redirect('/login?error=1');
 });
 
-app.get('/', (req, res) => {
+app.get('/logout', (req, res) => {
+  res.cookie('loggedIn', '', { expires: new Date(0) });
+  res.redirect('/login');
+});
+
+app.get('/', checkAuth, (req, res) => {
   res.sendFile(path.join(__dirname, 'views', 'dashboard.html'));
 });
 

--- a/views/dashboard.html
+++ b/views/dashboard.html
@@ -17,6 +17,7 @@
       <header>
         <h1>Neurolynx AI Automation Assistant</h1>
         <p class="tagline">Smarter selling for e-commerce brands</p>
+        <a href="/logout" class="logout-link">Logout</a>
       </header>
 
       <nav class="tab-nav">


### PR DESCRIPTION
## Summary
- add simple cookie parsing and auth middleware
- set login cookie after successful authentication
- add logout endpoint and link on dashboard

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_684d380eace883309af7f4293fdd1919